### PR TITLE
🎨 Palette: Implement keyboard navigation for command autocomplete

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -49,3 +49,7 @@
 ## 2024-05-25 - Autocomplete Accessibility Patterns
 **Learning:** Autocomplete suggestions should be interactive elements (buttons/options) not static divs, to support keyboard navigation and screen readers. When implementing a simple dropdown, ensure items are focusable.
 **Action:** Use `<button>` elements for simple suggestion lists, or `role="option"` inside `role="listbox"` for complex ones.
+
+## 2024-05-26 - Keyboard-Accessible Autocomplete
+**Learning:** Custom autocomplete widgets are often inaccessible to keyboard users unless arrow key navigation is explicitly managed. Relying on `Tab` to navigate suggestions is poor UX as it blocks access to subsequent elements.
+**Action:** Always implement `ArrowDown`, `ArrowUp`, and `Escape` handlers for custom dropdowns, and set `tabindex="-1"` on items to preserve natural tab flow while allowing arrow key navigation.

--- a/living_rusted_tankard/game/templates/enhanced_game.html
+++ b/living_rusted_tankard/game/templates/enhanced_game.html
@@ -543,12 +543,24 @@
                 
                 // Command history navigation
                 this.elements.commandInput.addEventListener('keydown', (e) => {
+                    const suggestionsVisible = !this.elements.inputSuggestions.classList.contains('hidden');
+
                     if (e.key === 'ArrowUp') {
                         e.preventDefault();
                         this.navigateHistory('up');
                     } else if (e.key === 'ArrowDown') {
+                        // Prioritize suggestions navigation if visible
+                        if (suggestionsVisible && this.elements.inputSuggestions.children.length > 0) {
+                            e.preventDefault();
+                            this.elements.inputSuggestions.firstElementChild.focus();
+                            return;
+                        }
+
                         e.preventDefault();
                         this.navigateHistory('down');
+                    } else if (e.key === 'Escape' && suggestionsVisible) {
+                        e.preventDefault();
+                        this.elements.inputSuggestions.classList.add('hidden');
                     }
                 });
                 
@@ -991,6 +1003,26 @@
                     btn.className = 'w-full text-left p-2 hover:bg-gray-600 cursor-pointer text-gray-300 hover:text-white transition-colors border-b border-gray-600 last:border-0 focus:outline-none focus:bg-gray-600';
                     const regex = new RegExp(`(${value})`, 'gi');
                     btn.innerHTML = match.replace(regex, '<span class="text-tavern-400 font-bold">$1</span>');
+
+                    // Accessible keyboard navigation
+                    btn.tabIndex = -1; // Remove from tab order to prevent blocking "Send" button
+                    btn.addEventListener('keydown', (e) => {
+                        if (e.key === 'ArrowDown') {
+                            e.preventDefault();
+                            if (btn.nextElementSibling) btn.nextElementSibling.focus();
+                        } else if (e.key === 'ArrowUp') {
+                            e.preventDefault();
+                            if (btn.previousElementSibling) {
+                                btn.previousElementSibling.focus();
+                            } else {
+                                this.elements.commandInput.focus();
+                            }
+                        } else if (e.key === 'Escape') {
+                            e.preventDefault();
+                            this.elements.inputSuggestions.classList.add('hidden');
+                            this.elements.commandInput.focus();
+                        }
+                    });
 
                     btn.addEventListener('click', () => {
                         this.elements.commandInput.value = match;


### PR DESCRIPTION
💡 What: Added keyboard navigation (ArrowUp, ArrowDown, Escape) to command autocomplete suggestions and removed them from the tab order.
🎯 Why: Keyboard users were unable to access suggestions without tabbing through the entire list or were forced to ignore them.
♿ Accessibility: Suggestions are now reachable via Arrow keys from the input, and do not block Tab navigation to the "Send" button. Escape closes the list.

---
*PR created automatically by Jules for task [9873578965426332479](https://jules.google.com/task/9873578965426332479) started by @CrazyDubya*