### PR TITLE
🎨 Palette: Autocomplete Keyboard Navigation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -49,3 +49,7 @@
 ## 2024-05-25 - Autocomplete Accessibility Patterns
 **Learning:** Autocomplete suggestions should be interactive elements (buttons/options) not static divs, to support keyboard navigation and screen readers. When implementing a simple dropdown, ensure items are focusable.
 **Action:** Use `<button>` elements for simple suggestion lists, or `role="option"` inside `role="listbox"` for complex ones.
+
+## 2026-01-28 - Autocomplete Keyboard Navigation Patterns
+**Learning:** Autocomplete components often break keyboard flow if they don't explicitly handle focus transfer. Users expect `ArrowDown` to move from the input to the suggestions list, and `Escape` to dismiss it without losing focus.
+**Action:** When implementing custom autocomplete, explicitly handle `ArrowDown` (input -> first item), `ArrowUp` (first item -> input), and `Escape` (close + focus input).

--- a/living_rusted_tankard/game/templates/enhanced_game.html
+++ b/living_rusted_tankard/game/templates/enhanced_game.html
@@ -543,6 +543,21 @@
                 
                 // Command history navigation
                 this.elements.commandInput.addEventListener('keydown', (e) => {
+                    const suggestionsVisible = !this.elements.inputSuggestions.classList.contains('hidden');
+
+                    if (suggestionsVisible) {
+                        if (e.key === 'ArrowDown') {
+                            e.preventDefault();
+                            const firstBtn = this.elements.inputSuggestions.querySelector('button');
+                            if (firstBtn) firstBtn.focus();
+                            return;
+                        } else if (e.key === 'Escape') {
+                            e.preventDefault();
+                            this.elements.inputSuggestions.classList.add('hidden');
+                            return;
+                        }
+                    }
+
                     if (e.key === 'ArrowUp') {
                         e.preventDefault();
                         this.navigateHistory('up');
@@ -998,6 +1013,28 @@
                         this.elements.inputSuggestions.classList.add('hidden');
                         this.elements.commandInput.focus();
                     });
+
+                    // Keyboard navigation for suggestions
+                    btn.addEventListener('keydown', (e) => {
+                        if (e.key === 'ArrowDown') {
+                            e.preventDefault();
+                            const next = btn.nextElementSibling;
+                            if (next) next.focus();
+                        } else if (e.key === 'ArrowUp') {
+                            e.preventDefault();
+                            const prev = btn.previousElementSibling;
+                            if (prev) {
+                                prev.focus();
+                            } else {
+                                this.elements.commandInput.focus();
+                            }
+                        } else if (e.key === 'Escape') {
+                            e.preventDefault();
+                            this.elements.inputSuggestions.classList.add('hidden');
+                            this.elements.commandInput.focus();
+                        }
+                    });
+
                     this.elements.inputSuggestions.appendChild(btn);
                 });
 


### PR DESCRIPTION
🎨 Palette: Autocomplete Keyboard Navigation

💡 What:
Added full keyboard navigation support to the command autocomplete feature in `enhanced_game.html`.

🎯 Why:
Users expect standard keyboard interactions for autocomplete dropdowns. Previously, `ArrowDown` hijacked the input for history navigation even when suggestions were visible, and there was no way to navigate suggestions without a mouse or close them with `Escape`.

♿ Accessibility:
- `ArrowDown` now moves focus from input to the first suggestion.
- Users can navigate suggestions with `ArrowUp` and `ArrowDown`.
- `ArrowUp` from the top suggestion returns focus to the input.
- `Escape` closes the suggestion list and returns focus to the input.
- Uses `e.preventDefault()` to avoid scrolling or conflicting actions.

Changes are localized to `living_rusted_tankard/game/templates/enhanced_game.html` and verified via Playwright.

---
*PR created automatically by Jules for task [14538199237285742294](https://jules.google.com/task/14538199237285742294) started by @CrazyDubya*