### PR TITLE
🎨 Palette: Smart Scroll & "New Messages" Indicator

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -53,3 +53,7 @@
 ## 2026-01-28 - Autocomplete Keyboard Navigation Patterns
 **Learning:** Autocomplete components often break keyboard flow if they don't explicitly handle focus transfer. Users expect `ArrowDown` to move from the input to the suggestions list, and `Escape` to dismiss it without losing focus.
 **Action:** When implementing custom autocomplete, explicitly handle `ArrowDown` (input -> first item), `ArrowUp` (first item -> input), and `Escape` (close + focus input).
+
+## 2024-05-27 - Smart Scroll Preservation
+**Learning:** In chat-like interfaces, auto-scrolling on new messages disrupts users who are reading history. A better pattern is to suppress auto-scroll when the user has manually scrolled up, and provide a clear "New Messages" or "Scroll to Bottom" indicator to jump back to the latest content.
+**Action:** Implement smart scroll detection: only auto-scroll if the user is already at the bottom (or explicitly triggers an action).

--- a/living_rusted_tankard/game/templates/enhanced_game.html
+++ b/living_rusted_tankard/game/templates/enhanced_game.html
@@ -233,7 +233,7 @@
             </header>
             
             <!-- Enhanced Narrative Feed -->
-            <div id="main-content" tabindex="-1" class="flex-1 bg-gradient-to-b from-gray-800 to-gray-900 rounded-lg shadow-lg overflow-hidden border border-gray-700 outline-none">
+            <div id="main-content" tabindex="-1" class="flex-1 bg-gradient-to-b from-gray-800 to-gray-900 rounded-lg shadow-lg overflow-hidden border border-gray-700 outline-none relative">
                 <div id="narrative-content" aria-live="polite" aria-atomic="false" role="log" class="narrative-feed overflow-y-auto p-4 md:p-6 space-y-4 custom-scrollbar">
                     <!-- Initial loading message - real welcome comes from server -->
                     <div id="initial-loading" class="bg-gradient-to-r from-tavern-900 to-gray-800 border-l-4 border-tavern-400 p-4 rounded-r-lg animate-fade-in text-center">
@@ -251,6 +251,13 @@
                 <div id="loading-indicator" class="hidden p-2 text-center text-tavern-400">
                     <span class="loading-dots">Weaving the tale</span>
                 </div>
+
+                <!-- Scroll to Bottom Button -->
+                <button id="scroll-bottom-btn" aria-label="Scroll to bottom" class="hidden absolute bottom-4 right-4 bg-tavern-500 hover:bg-tavern-600 text-white p-3 rounded-full shadow-lg transition-all z-10 animate-bounce-subtle focus:outline-none focus:ring-2 focus:ring-white">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 14l-7 7m0 0l-7-7m7 7V3" />
+                    </svg>
+                </button>
             </div>
             
             <!-- Enhanced Command Input -->
@@ -466,6 +473,8 @@
                 this.historyIndex = -1;
                 this.isLoading = false;
                 this.performanceOptimized = localStorage.getItem('performanceOptimized') !== 'false';
+                this.userHasScrolledUp = false;
+                this.scrollTicking = false;
                 
                 this.initializeInterface();
                 this.bindEvents();
@@ -489,7 +498,8 @@
                     historyToggle: document.getElementById('history-toggle'),
                     historyPanel: document.getElementById('command-history-panel'),
                     historyList: document.getElementById('command-history-list'),
-                    inputSuggestions: document.getElementById('input-suggestions')
+                    inputSuggestions: document.getElementById('input-suggestions'),
+                    scrollBottomBtn: document.getElementById('scroll-bottom-btn')
                 };
                 
                 // Enable submit button when there's input
@@ -672,6 +682,34 @@
                 document.getElementById('mobile-menu-toggle').addEventListener('click', () => {
                     document.getElementById('sidebar').scrollIntoView({ behavior: 'smooth' });
                 });
+
+                // Scroll handling
+                this.elements.narrativeContent.addEventListener('scroll', () => {
+                    this.handleScroll();
+                });
+
+                this.elements.scrollBottomBtn.addEventListener('click', () => {
+                    this.scrollToBottom(true);
+                });
+            }
+
+            handleScroll() {
+                if (this.scrollTicking) return;
+
+                this.scrollTicking = true;
+                window.requestAnimationFrame(() => {
+                    const el = this.elements.narrativeContent;
+                    // If we are close to bottom (within 50px), we consider it "at bottom"
+                    const isAtBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 50;
+                    this.userHasScrolledUp = !isAtBottom;
+
+                    if (this.userHasScrolledUp) {
+                        this.elements.scrollBottomBtn.classList.remove('hidden');
+                    } else {
+                        this.elements.scrollBottomBtn.classList.add('hidden');
+                    }
+                    this.scrollTicking = false;
+                });
             }
             
             async submitCommand() {
@@ -802,7 +840,7 @@
                 }
                 
                 // Auto-scroll to bottom
-                this.scrollToBottom();
+                this.scrollToBottom(isPlayer);
             }
             
             formatNarrativeText(text) {
@@ -1107,9 +1145,17 @@
                 }
             }
             
-            scrollToBottom() {
+            scrollToBottom(force = false) {
+                // If user is reading history (scrolled up) and it's not a forced scroll, don't scroll
+                if (this.userHasScrolledUp && !force) {
+                    return;
+                }
+
                 setTimeout(() => {
                     this.elements.narrativeContent.scrollTop = this.elements.narrativeContent.scrollHeight;
+                    // Reset scroll state since we just forced it to bottom
+                    this.userHasScrolledUp = false;
+                    this.elements.scrollBottomBtn.classList.add('hidden');
                 }, 100);
             }
             


### PR DESCRIPTION
💡 What: Implemented a smart scroll-to-bottom feature for the narrative feed.
🎯 Why: Users reading previous history were being forcibly scrolled to the bottom when new messages arrived (e.g., from background events or delayed responses), causing frustration and loss of reading context.
📸 Before/After: Added a floating "Scroll to Bottom" button that only appears when the user scrolls up.
♿ Accessibility: Button has `aria-label`, is keyboard accessible, and uses high contrast colors.


---
*PR created automatically by Jules for task [10855134812131661232](https://jules.google.com/task/10855134812131661232) started by @CrazyDubya*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/UX change that only affects client-side scrolling behavior in the narrative feed; main risk is unintended scroll/visibility edge cases across browsers and screen sizes.
> 
> **Overview**
> Adds *smart scroll preservation* to the narrative feed so new messages no longer force-scroll users who have manually scrolled up.
> 
> Introduces a floating, accessible `scroll-bottom-btn` that appears when not near the bottom, plus a throttled scroll listener and an updated `scrollToBottom(force)` that only auto-scrolls when appropriate (or when the user explicitly clicks the button). Also records the pattern in `.Jules/palette.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03305b688366f42cdad5cccef430bfbfb2a77afb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->