### PR TITLE
🎨 Palette: Add Smart Scroll to narrative feed

### DIFF
--- a/living_rusted_tankard/game/templates/enhanced_game.html
+++ b/living_rusted_tankard/game/templates/enhanced_game.html
@@ -233,7 +233,7 @@
             </header>
             
             <!-- Enhanced Narrative Feed -->
-            <div id="main-content" tabindex="-1" class="flex-1 bg-gradient-to-b from-gray-800 to-gray-900 rounded-lg shadow-lg overflow-hidden border border-gray-700 outline-none">
+            <div id="main-content" tabindex="-1" class="relative flex-1 bg-gradient-to-b from-gray-800 to-gray-900 rounded-lg shadow-lg overflow-hidden border border-gray-700 outline-none">
                 <div id="narrative-content" aria-live="polite" aria-atomic="false" role="log" class="narrative-feed overflow-y-auto p-4 md:p-6 space-y-4 custom-scrollbar">
                     <!-- Initial loading message - real welcome comes from server -->
                     <div id="initial-loading" class="bg-gradient-to-r from-tavern-900 to-gray-800 border-l-4 border-tavern-400 p-4 rounded-r-lg animate-fade-in text-center">
@@ -251,6 +251,11 @@
                 <div id="loading-indicator" class="hidden p-2 text-center text-tavern-400">
                     <span class="loading-dots">Weaving the tale</span>
                 </div>
+
+                <!-- Smart Scroll Button -->
+                <button id="scroll-to-bottom" class="hidden absolute bottom-6 right-6 bg-tavern-500 hover:bg-tavern-400 text-white w-10 h-10 rounded-full shadow-lg transition-all z-10 flex items-center justify-center animate-bounce-subtle focus:outline-none focus:ring-2 focus:ring-tavern-400 opacity-90 hover:opacity-100" aria-label="Scroll to bottom" title="Scroll to bottom">
+                    <span class="text-xl">⬇️</span>
+                </button>
             </div>
             
             <!-- Enhanced Command Input -->
@@ -489,7 +494,8 @@
                     historyToggle: document.getElementById('history-toggle'),
                     historyPanel: document.getElementById('command-history-panel'),
                     historyList: document.getElementById('command-history-list'),
-                    inputSuggestions: document.getElementById('input-suggestions')
+                    inputSuggestions: document.getElementById('input-suggestions'),
+                    scrollToBottomBtn: document.getElementById('scroll-to-bottom')
                 };
                 
                 // Enable submit button when there's input
@@ -672,6 +678,37 @@
                 document.getElementById('mobile-menu-toggle').addEventListener('click', () => {
                     document.getElementById('sidebar').scrollIntoView({ behavior: 'smooth' });
                 });
+
+                // Smart Scroll
+                this.elements.narrativeContent.addEventListener('scroll', () => {
+                    // Simple throttle
+                    if (!this.scrollTicking) {
+                        window.requestAnimationFrame(() => {
+                            this.handleScroll();
+                            this.scrollTicking = false;
+                        });
+                        this.scrollTicking = true;
+                    }
+                });
+
+                this.elements.scrollToBottomBtn.addEventListener('click', () => {
+                    this.elements.narrativeContent.scrollTo({
+                        top: this.elements.narrativeContent.scrollHeight,
+                        behavior: 'smooth'
+                    });
+                });
+            }
+
+            handleScroll() {
+                const { scrollTop, scrollHeight, clientHeight } = this.elements.narrativeContent;
+                // Show button if we are more than 150px from bottom
+                const isScrolledUp = scrollTop + clientHeight < scrollHeight - 150;
+
+                if (isScrolledUp) {
+                    this.elements.scrollToBottomBtn.classList.remove('hidden');
+                } else {
+                    this.elements.scrollToBottomBtn.classList.add('hidden');
+                }
             }
             
             async submitCommand() {


### PR DESCRIPTION
Implemented a "Smart Scroll" button in `enhanced_game.html`. The button is hidden by default and appears when the user scrolls up in the narrative feed. Clicking it smooth-scrolls the user back to the bottom. This addresses a common usability issue in chat-like interfaces where returning to the latest message can be tedious after reviewing history. Validated with Playwright script and manual screenshot inspection.

---
*PR created automatically by Jules for task [11082163963815508820](https://jules.google.com/task/11082163963815508820) started by @CrazyDubya*